### PR TITLE
feat: add simple test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/**/*.tsbuildinfo
+dist/tests
 node_modules
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "tsc",
     "build:watch": "tsc --watch",
     "lint": "eslint --ext .ts lib",
-    "lint:fix": "eslint --fix --ext .ts lib"
+    "lint:fix": "eslint --fix --ext .ts lib",
+    "test": "ts-node tests/index.ts"
   },
   "devDependencies": {
     "@edge/eslint-config-typescript": "^0.1.1",

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,0 +1,33 @@
+// Copyright (C) 2021 Edge Network Technologies Limited
+// Use of this source code is governed by a GNU GPL-style license
+// that can be found in the LICENSE.md file. All rights reserved.
+
+import { Log, LogContext, StdioAdaptor } from '../lib'
+
+// this is not a 'proper' test script at this stage, as it does not handle pass/failure cases;
+// it is just here to provide test logging output for inspection
+
+const log = new Log()
+log.use(new StdioAdaptor())
+
+const messages: [string, LogContext?][] = [
+  ['abc'],
+  ['def', { value1: 'xyz', value2: Math.random() }],
+  ['ghi', {}],
+  ['jkl', {
+    value1: Math.random(),
+    time: Date.now(),
+    value2: Math.random(),
+    value3: Math.random(),
+    randint: Math.floor(Math.random() * 1e6),
+    value4: 'zyx'
+  }],
+  ['mno', 'unnamed value']
+]
+
+messages.forEach(([msg, ctx]) => {
+  log.debug(msg, ctx)
+  log.info(msg, ctx)
+  log.warn(msg, ctx)
+  log.error(msg, ctx)
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
   },
   "include": [
     "lib/**/*",
+    "tests/**/*"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Created in the course of investigating #8 

This provides a simple way to produce some output through the stdio adapter that we can manually review. This enables an extra check before publishing or testing in another application.

Future plans could include proper automated pass/fail testing, but for now this is nice to have.