### PR TITLE
fix: error display in different usages

### DIFF
--- a/tests/index.ts
+++ b/tests/index.ts
@@ -42,5 +42,6 @@ messages.forEach(([msg, ctx]) => {
     log.info(msg)
     log.warn(msg)
     log.error(msg)
+    log.error('msg is context', { msg })
   }
 })


### PR DESCRIPTION
Further to https://github.com/edge/log/issues/13#issuecomment-994644151 and discussions in Discord, I have taken a holistic approach to deconstructing errors for logging. Rather than just focusing on errors, I separated out the mechanisms for serializing and merging context data for better control over formatting of the supported types.

The new `SerializedLogContext` is a simplified form of `LogContext` that eliminates objects except for generic string records and `null`, improving the predictability of merge behaviours.

I've also tweaked the tests to show how each record type is represented when given as a context property.

closes #13