### PR TITLE
v1.3.1

### DIFF
--- a/dist/lib/index.js
+++ b/dist/lib/index.js
@@ -170,14 +170,17 @@ var Log = (function () {
     };
     Log.prototype.extend = function (name, context) {
         if (typeof name === 'string' && context) {
-            return new Log(this.adaptors, this.name + ":" + name, this.level, this.mergeContexts(context));
+            return new Log(this.adaptors, [this.name, name].filter(Boolean).join(':'), this.level, this.mergeContexts(context));
         }
-        else if (typeof name === 'string')
-            return new Log(this.adaptors, this.name + ":" + name, this.level, this.context);
-        else if (name)
+        else if (typeof name === 'string') {
+            return new Log(this.adaptors, [this.name, name].filter(Boolean).join(':'), this.level, this.context);
+        }
+        else if (name) {
             return new Log(this.adaptors, this.name, this.level, this.mergeContexts(name));
-        else
+        }
+        else {
             return new Log(this.adaptors, this.name, this.level, this.context);
+        }
     };
     Log.prototype.mergeContexts = function (context) {
         return mergeContexts(context, __assign({}, this.context));

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -187,12 +187,18 @@ export class Log {
     if (typeof name === 'string' && context) {
       return new Log(
         this.adaptors,
-        `${this.name}:${name}`,
+        [this.name, name].filter(Boolean).join(':'),
         this.level, this.mergeContexts(context))
     }
-    else if (typeof name === 'string') return new Log(this.adaptors, `${this.name}:${name}`, this.level, this.context)
-    else if (name) return new Log(this.adaptors, this.name, this.level, this.mergeContexts(name))
-    else return new Log(this.adaptors, this.name, this.level, this.context)
+    else if (typeof name === 'string') {
+      return new Log(this.adaptors, [this.name, name].filter(Boolean).join(':'), this.level, this.context)
+    }
+    else if (name) {
+      return new Log(this.adaptors, this.name, this.level, this.mergeContexts(name))
+    }
+    else {
+      return new Log(this.adaptors, this.name, this.level, this.context)
+    }
   }
 
   private mergeContexts(context?: LogContext): Record<string, unknown> | undefined {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge/log",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Logging utility library with powerful adaptor middleware",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Edge Network <core@edge.network>",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "ts-node tests/index.ts"
   },
   "devDependencies": {
-    "@edge/eslint-config-typescript": "^0.1.1",
+    "@edge/eslint-config-typescript": "^0.1.4",
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.32.0",
     "eslint": "^7.32.0",


### PR DESCRIPTION
1. Updated ESLint rules to allow more spacing around some fairly dense code
2. Updated name handling when extending logger to prevent `undefined` being rendered as logger namespace

Example:

![image](https://user-images.githubusercontent.com/129557/152842669-e83a3bfc-ba1d-4143-a03e-e8ab66ef19f7.png)
